### PR TITLE
Re-integrate cocoapods keys

### DIFF
--- a/AnotherFeedlyApp/Spotify.swift
+++ b/AnotherFeedlyApp/Spotify.swift
@@ -1,23 +1,15 @@
 import Foundation
-
-let kClientKey = "FEEDLY_CLIENT"
-let kFeedlySecretKey = "FEEDLY_SECRET"
+import Keys
 
 struct Auth {
     let redirectUri = "https://localhost/"
     let scope = "https://cloud.feedly.com/subscriptions"
     var clientId: String {
-        guard let client = ProcessInfo.processInfo.environment[kClientKey] else {
-            fatalError("🐛 ERROR: No Environment variable \(kClientKey)")
-        }
-        return client
+        return AnotherFeedlyAppKeys().fEEDLY_CLIENT
     }
 
     var clientSecret: String {
-        guard let client = ProcessInfo.processInfo.environment[kFeedlySecretKey] else {
-            fatalError("🐛 ERROR: No Environment variable \(kFeedlySecretKey)")
-        }
-        return client
+        return AnotherFeedlyAppKeys().fEEDLY_SECRET
     }
 }
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org' do
     gem 'cocoapods'
+    gem 'cocoapods-keys'
     gem 'danger'
     gem 'danger-xcov'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (2.3.4)
+    RubyInline (3.12.4)
+      ZenTest (~> 4.3)
+    ZenTest (4.11.1)
     activesupport (4.2.7.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -40,6 +43,9 @@ GEM
       nap (~> 1.0)
     cocoapods-deintegrate (1.0.1)
     cocoapods-downloader (1.1.3)
+    cocoapods-keys (2.0.0)
+      dotenv
+      osx_keychain
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
@@ -165,6 +171,8 @@ GEM
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
     os (0.9.6)
+    osx_keychain (1.0.1)
+      RubyInline (~> 3)
     plist (3.2.0)
     public_suffix (2.0.5)
     representable (2.3.0)
@@ -214,6 +222,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods!
+  cocoapods-keys!
   danger!
   danger-xcov!
 

--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,11 @@
+plugin 'cocoapods-keys', {
+  :project => "AnotherFeedlyApp",
+  :keys => [
+    "FEEDLY_CLIENT",
+    "FEEDLY_SECRET",
+  ]
+}
+
 target 'AnotherFeedlyApp' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,15 +1,22 @@
 PODS:
+  - Keys (1.0.0)
   - SwiftGen (4.1.0)
   - SwiftLint (0.16.0)
 
 DEPENDENCIES:
+  - Keys (from `Pods/CocoaPodsKeys`)
   - SwiftGen
   - SwiftLint
 
+EXTERNAL SOURCES:
+  Keys:
+    :path: Pods/CocoaPodsKeys
+
 SPEC CHECKSUMS:
+  Keys: 9c35bf00f612ee1d48556f4a4b9b4551e224e90f
   SwiftGen: d29fd8b7aa52092411d415fb09d0abd3d79ea1a5
   SwiftLint: 90665265ae50b58167c674a11c680bbabe9d6513
 
-PODFILE CHECKSUM: 3c58a553354fc249495c234dda658e1370daa16b
+PODFILE CHECKSUM: e2c19e06bd197791feb77198d8e7ef97145e4eb6
 
 COCOAPODS: 1.1.1


### PR DESCRIPTION
No more crazy environment variables (well too much).

Cocoapods keys keeps my code smaller, and feels like it does for keys what swift gen does for my storyboards. Make a thing that I can just call to get a constant back.

Note you must define `FEEDLY_CLIENT` and `FEEDLY_SECRET` in the build machines environment.