### PR TITLE
Add AuthData Protocol.

### DIFF
--- a/AnotherFeedlyApp.xcodeproj/project.pbxproj
+++ b/AnotherFeedlyApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5239B9831E5D59CF005509D8 /* URLRequest-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5239B9821E5D59CF005509D8 /* URLRequest-Extensions.swift */; };
 		525469C91E31C1A1009CDA21 /* UIWindow+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525469C81E31C1A1009CDA21 /* UIWindow+Extensions.swift */; };
 		5273A4A21E2719F300633F6A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5273A4A11E2719F300633F6A /* AppDelegate.swift */; };
 		5273A4A71E2719F300633F6A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5273A4A51E2719F300633F6A /* Main.storyboard */; };
@@ -39,6 +40,7 @@
 /* Begin PBXFileReference section */
 		35C934987ED87D28CB75AA0F /* Pods-AnotherFeedlyApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AnotherFeedlyApp.release.xcconfig"; path = "Pods/Target Support Files/Pods-AnotherFeedlyApp/Pods-AnotherFeedlyApp.release.xcconfig"; sourceTree = "<group>"; };
 		3B723414805BF8067B12A136 /* Pods-AnotherFeedlyAppTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AnotherFeedlyAppTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AnotherFeedlyAppTests/Pods-AnotherFeedlyAppTests.debug.xcconfig"; sourceTree = "<group>"; };
+		5239B9821E5D59CF005509D8 /* URLRequest-Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URLRequest-Extensions.swift"; sourceTree = "<group>"; };
 		525469C81E31C1A1009CDA21 /* UIWindow+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWindow+Extensions.swift"; sourceTree = "<group>"; };
 		52564C121E2BFBEA0085D7F4 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		5273A49E1E2719F300633F6A /* AnotherFeedlyApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AnotherFeedlyApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -85,6 +87,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5239B9811E5D5998005509D8 /* UIKit-Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				5239B9821E5D59CF005509D8 /* URLRequest-Extensions.swift */,
+				525469C81E31C1A1009CDA21 /* UIWindow+Extensions.swift */,
+			);
+			name = "UIKit-Extensions";
+			sourceTree = "<group>";
+		};
 		5273A4951E2719F300633F6A = {
 			isa = PBXGroup;
 			children = (
@@ -114,13 +125,14 @@
 				529AABD51E287088000C62A1 /* Feedly.swift */,
 				529AABE51E288F21000C62A1 /* main.swift */,
 				5273A4A11E2719F300633F6A /* AppDelegate.swift */,
-				525469C81E31C1A1009CDA21 /* UIWindow+Extensions.swift */,
 				52EEB52E1E28AAA000F55421 /* AppCoordinator.swift */,
 				5273A4A51E2719F300633F6A /* Main.storyboard */,
 				529AABD11E28601F000C62A1 /* SignInViewController.swift */,
 				5273A4A81E2719F300633F6A /* Assets.xcassets */,
 				5273A4AA1E2719F300633F6A /* LaunchScreen.storyboard */,
 				5273A4AD1E2719F400633F6A /* Info.plist */,
+				52EEB52D1E28A91000F55421 /* SwiftGenConstants */,
+				5239B9811E5D5998005509D8 /* UIKit-Extensions */,
 			);
 			path = AnotherFeedlyApp;
 			sourceTree = "<group>";
@@ -401,6 +413,7 @@
 			files = (
 				5273A4A21E2719F300633F6A /* AppDelegate.swift in Sources */,
 				529AABD61E287088000C62A1 /* Feedly.swift in Sources */,
+				5239B9831E5D59CF005509D8 /* URLRequest-Extensions.swift in Sources */,
 				52EEB52A1E28A3DC00F55421 /* Storyboards.swift in Sources */,
 				52EEB52F1E28AAA000F55421 /* AppCoordinator.swift in Sources */,
 				529AABD21E28601F000C62A1 /* SignInViewController.swift in Sources */,

--- a/AnotherFeedlyApp/AppCoordinator.swift
+++ b/AnotherFeedlyApp/AppCoordinator.swift
@@ -14,38 +14,11 @@ class AppCoordinator {
     func appLaunched(options: [UIApplicationLaunchOptionsKey : Any]? = nil) {
 
         let signInVC = StoryboardScene.Main.instantiateWebViewController()
-        let signInWebViewDelegate = InterestingWebViewDelegate(completion: signInComplete,
+        let signInWebViewDelegate = InterestingWebViewDelegate(completion: feedly.signInFinished,
                                                           urlOfInterest: auth.redirectUri)
         signInVC.urlRequest = feedly.signInRequest
         signInVC.webViewDelegate = signInWebViewDelegate
         window.rootViewController = signInVC
     }
 
-    func signInComplete(withRedirectRequest request: URLRequest) {
-        print("OMG Sign In Complete")
-        guard let code = request.extractAuthCodeFromRedirect() else {
-            print("Called us back but with no code?")
-            return
-        }
-        feedly.requestToken(withCode: code, completion: saveToken)
-    }
-
-    func saveToken(token: FeedlyToken) {
-        print("SavingToken")
-    }
-
-}
-
-extension URLRequest {
-    func extractAuthCodeFromRedirect() -> String? {
-        guard let url = url else { return nil }
-        let components = NSURLComponents(string: url.absoluteString)
-        guard let items = components?.queryItems else {
-            return nil
-        }
-        let code = items.filter { (item) -> Bool in
-            return item.name == "code"
-        }
-        return code.first?.value
-    }
 }

--- a/AnotherFeedlyApp/AppCoordinator.swift
+++ b/AnotherFeedlyApp/AppCoordinator.swift
@@ -5,7 +5,7 @@ class AppCoordinator {
     let window: UIWindow
 
     let auth = Auth()
-    lazy var feedly: Feedly = { Feedly(auth: self.auth) }()
+    lazy var feedly: FeedlySignIn = { FeedlySignIn(auth: self.auth) }()
 
     init(window: UIWindow) {
         self.window = window

--- a/AnotherFeedlyApp/Constants/Storyboards.swift
+++ b/AnotherFeedlyApp/Constants/Storyboards.swift
@@ -2,7 +2,6 @@
 
 import Foundation
 import UIKit
-import AnotherFeedlyApp
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
@@ -14,7 +13,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {
@@ -42,7 +41,7 @@ extension UIViewController {
   }
 }
 
-struct StoryboardScene {
+enum StoryboardScene {
   enum LaunchScreen: StoryboardSceneType {
     static let storyboardName = "LaunchScreen"
   }
@@ -60,5 +59,7 @@ struct StoryboardScene {
   }
 }
 
-struct StoryboardSegue {
+enum StoryboardSegue {
 }
+
+private final class BundleToken {}

--- a/AnotherFeedlyApp/Feedly.swift
+++ b/AnotherFeedlyApp/Feedly.swift
@@ -109,7 +109,6 @@ class FeedlySignIn {
 
         func handleNetworkResponse(data: Data?, response: URLResponse?, err: Error?) {
             guard err == nil else {
-                print("\((err as? NSError)?.localizedDescription)")
                 completion(.error(err!))
                 return
             }

--- a/AnotherFeedlyApp/Feedly.swift
+++ b/AnotherFeedlyApp/Feedly.swift
@@ -9,7 +9,7 @@ protocol AuthData {
     var clientSecret: String { get }
 }
 
-class Feedly {
+class FeedlySignIn {
 
     let auth: AuthData
     let session: URLSession
@@ -116,7 +116,6 @@ class Feedly {
         return handleNetworkResponse
     }
 }
-
 
 struct FeedlyToken {
 

--- a/AnotherFeedlyApp/Feedly.swift
+++ b/AnotherFeedlyApp/Feedly.swift
@@ -2,9 +2,17 @@ import Foundation
 
 fileprivate let defaultSession = URLSession(configuration: URLSessionConfiguration.default)
 
+protocol AuthData {
+    var redirectUri: String { get }
+    var scope: String { get }
+    var clientId: String { get }
+    var clientSecret: String { get }
+}
+
+
 struct Feedly {
 
-    let auth: Auth
+    let auth: AuthData
     let session: URLSession
 
     let base = "https://sandbox.feedly.com"
@@ -15,7 +23,7 @@ struct Feedly {
         return URLRequest(url: signInURL)
     }
 
-    init(auth: Auth, session: URLSession = defaultSession) {
+    init(auth: AuthData, session: URLSession = defaultSession) {
         self.auth = auth
         self.session = session
     }
@@ -28,7 +36,7 @@ struct Feedly {
         return url.url!
     }
 
-    private func signInQueryItems(authInfo: Auth) -> [URLQueryItem] {
+    private func signInQueryItems(authInfo: AuthData) -> [URLQueryItem] {
         let response_type = URLQueryItem(name: "response_type", value: "code")
         let client_id = URLQueryItem(name: "client_id", value: authInfo.clientId)
         let redirect_uri = URLQueryItem(name: "redirect_uri", value: authInfo.redirectUri)

--- a/AnotherFeedlyApp/Feedly.swift
+++ b/AnotherFeedlyApp/Feedly.swift
@@ -9,7 +9,6 @@ protocol AuthData {
     var clientSecret: String { get }
 }
 
-
 struct Feedly {
 
     let auth: AuthData

--- a/AnotherFeedlyApp/Feedly.swift
+++ b/AnotherFeedlyApp/Feedly.swift
@@ -9,7 +9,7 @@ protocol AuthData {
     var clientSecret: String { get }
 }
 
-struct Feedly {
+class Feedly {
 
     let auth: AuthData
     let session: URLSession
@@ -43,9 +43,23 @@ struct Feedly {
         return [response_type, client_id, redirect_uri, scope]
     }
 
+    func signInFinished(request: URLRequest) {
+        print("OMG Sign In Complete")
+        guard let code = request.extractAuthCodeFromRedirect() else {
+            print("Called us back but with no code?")
+            return
+        }
+        requestToken(withCode: code) { (token) in
+            //save token
+            //call back to AppCoordinator, Token succesfully gotten
+        }
+    }
+
     /// Once you have a code from the OAuth redirect, you can use it here to
     /// request a token from the Feedly API. This will give you an authorized
     /// token you can use to talk to the api with
+    ///
+    /// NOTE: Literally just making a network call, nothing to see here. (NO Tests required)
     func requestToken(withCode code: String, completion: @escaping (FeedlyToken) -> Void) {
         let req = tokenRequest(code: code)
         let task = session.dataTask(with: req, completionHandler: tokenResponseHandler(completion))
@@ -103,12 +117,11 @@ struct Feedly {
     }
 }
 
+
 struct FeedlyToken {
 
     init(data: Data) {
         let json = try? JSONSerialization.jsonObject(with: data, options: [])
-        print("🏄🏄🏄🏄🏄🏄🏄🏄🏄🏄🏄")
-        print(json)
     }
 
 }

--- a/AnotherFeedlyApp/SignInViewController.swift
+++ b/AnotherFeedlyApp/SignInViewController.swift
@@ -33,7 +33,8 @@ class InterestingWebViewDelegate: NSObject, WKNavigationDelegate {
     }
 
     //swiftlint:disable:next line_length
-    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
+                 decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         decideIf(requestIsInteresting: navigationAction.request, AndCallCorrectHandler: decisionHandler)
     }
 

--- a/AnotherFeedlyApp/URLRequest-Extensions.swift
+++ b/AnotherFeedlyApp/URLRequest-Extensions.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension URLRequest {
+    func extractAuthCodeFromRedirect() -> String? {
+        guard let url = url else { return nil }
+        let components = NSURLComponents(string: url.absoluteString)
+        guard let items = components?.queryItems else {
+            return nil
+        }
+        let code = items.filter { (item) -> Bool in
+            return item.name == "code"
+        }
+        return code.first?.value
+    }
+}

--- a/AnotherFeedlyAppTests/AnotherFeedlyAppTests.swift
+++ b/AnotherFeedlyAppTests/AnotherFeedlyAppTests.swift
@@ -133,7 +133,7 @@ class CodeExtraction: XCTestCase {
         let auth = Auth()
         let feedly = Feedly(auth: auth)
 
-        let json = feedly.tokenRequestJSON(code: code)
+        let json = feedly.tokenRequestPayload(code: code)
         guard let unSerialized = try? JSONSerialization.jsonObject(with: json, options: []) else {
             fatalError("json data cant be de-serialized")
         }

--- a/AnotherFeedlyAppTests/AnotherFeedlyAppTests.swift
+++ b/AnotherFeedlyAppTests/AnotherFeedlyAppTests.swift
@@ -87,7 +87,7 @@ class SignInViewControllerTests: XCTestCase {
         let signIn = StoryboardScene.Main.instantiateWebViewController()
         let delegate = InterestingWebViewDelegate(completion: {_ in }, urlOfInterest: "Whatever")
         signIn.webViewDelegate = delegate
-        signIn.urlRequest = Feedly(auth: auth).signInRequest
+        signIn.urlRequest = FeedlySignIn(auth: auth).signInRequest
 
         _ = signIn.view
 
@@ -101,7 +101,7 @@ class SignInViewControllerTests: XCTestCase {
         let mockWebView = MockWebView()
 
         signIn.webView = mockWebView
-        signIn.urlRequest = Feedly(auth: auth).signInRequest
+        signIn.urlRequest = FeedlySignIn(auth: auth).signInRequest
 
         _ = signIn.view
 
@@ -131,7 +131,7 @@ class CodeExtraction: XCTestCase {
         let code = "12345"
 
         let auth = Auth()
-        let feedly = Feedly(auth: auth)
+        let feedly = FeedlySignIn(auth: auth)
 
         let json = feedly.tokenRequestPayload(code: code)
         guard let unSerialized = try? JSONSerialization.jsonObject(with: json, options: []) else {
@@ -144,7 +144,7 @@ class CodeExtraction: XCTestCase {
     func testBuildRequestJSON() {
 
         let auth = Auth()
-        let feedly = Feedly(auth: auth)
+        let feedly = FeedlySignIn(auth: auth)
 
         let req = feedly.tokenRequest(code: "12345")
 
@@ -156,7 +156,7 @@ class CodeExtraction: XCTestCase {
     func testNetworkResponseHandlerAll_ForAuthTokenRequest() {
 
         let auth = Auth()
-        let feedly = Feedly(auth: auth)
+        let feedly = FeedlySignIn(auth: auth)
 
         let exp = expectation(description: "token was returned")
 
@@ -173,8 +173,3 @@ class CodeExtraction: XCTestCase {
 
     }
 }
-
-// What we really need to do is take the code that we got back, and put in in a json dict,
-// then POST that dict to /v2/auth/token
-
-// Then from that response we make a little user with a token.

--- a/AnotherFeedlyAppTests/AnotherFeedlyAppTests.swift
+++ b/AnotherFeedlyAppTests/AnotherFeedlyAppTests.swift
@@ -160,15 +160,21 @@ class CodeExtraction: XCTestCase {
 
         let exp = expectation(description: "token was returned")
 
-        let handler = feedly.tokenResponseHandler { _ in
-            exp.fulfill()
+        let handler = feedly.tokenResponseHandler { result in
+            switch result {
+            case .success(let token):
+                XCTFail("Should not get token without passing data (only error)")
+            case .error(let error):
+                exp.fulfill()
+            }
         }
         let err = NSError(domain: "networkFail", code: 1234, userInfo: nil)
         handler(nil, nil, err)
 
-        waitForExpectations(timeout: 3) { (err) in
-            guard let err = err else { return XCTFail() }
-            return XCTFail("\(err.localizedDescription)")
+        waitForExpectations(timeout: 3) { (error) in
+            if let error = error {
+                XCTFail("\(error.localizedDescription)")
+            }
         }
 
     }

--- a/AnotherFeedlyAppTests/AnotherFeedlyAppTests.swift
+++ b/AnotherFeedlyAppTests/AnotherFeedlyAppTests.swift
@@ -152,6 +152,26 @@ class CodeExtraction: XCTestCase {
         XCTAssertNotNil(req.httpBody)
         XCTAssertEqual(req.url?.absoluteString.contains("auth/token"), true)
     }
+
+    func testNetworkResponseHandlerAll_ForAuthTokenRequest() {
+
+        let auth = Auth()
+        let feedly = Feedly(auth: auth)
+
+        let exp = expectation(description: "token was returned")
+
+        let handler = feedly.tokenResponseHandler { _ in
+            exp.fulfill()
+        }
+        let err = NSError(domain: "networkFail", code: 1234, userInfo: nil)
+        handler(nil, nil, err)
+
+        waitForExpectations(timeout: 3) { (err) in
+            guard let err = err else { return XCTFail() }
+            return XCTFail("\(err.localizedDescription)")
+        }
+
+    }
 }
 
 // What we really need to do is take the code that we got back, and put in in a json dict,

--- a/Auth.swift
+++ b/Auth.swift
@@ -19,3 +19,5 @@ struct Auth {
         self.scope = scope
     }
 }
+
+extension Auth: AuthData { }


### PR DESCRIPTION
This allows Feedly to not have to know about any thing about the auth
struct. This reduces coupling, and make future feedly extraction easier.