### PR TITLE
Remove hound config.

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,0 @@
-swift:
-    enabled: true


### PR DESCRIPTION
Swift lint is now run as part of Danger. Hound is no longer used

Fixes #14 