### PR TITLE
Update Swiftlint

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Keys (1.0.0)
   - SwiftGen (4.2.0)
-  - SwiftLint (0.16.1)
+  - SwiftLint (0.17.0)
 
 DEPENDENCIES:
   - Keys (from `Pods/CocoaPodsKeys`)
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Keys: 9c35bf00f612ee1d48556f4a4b9b4551e224e90f
   SwiftGen: b6bfed151243348e4603b91bf5bc4eb2486c9d5b
-  SwiftLint: b8b683208cc09640898f16318a7a452274e91f61
+  SwiftLint: 9fb1dd71d5952d130f8c2fb60ae2e1475cf5d575
 
 PODFILE CHECKSUM: e2c19e06bd197791feb77198d8e7ef97145e4eb6
 


### PR DESCRIPTION
New swiftlint version

Updated from 16.1 -> 17.0

Lots of new rules in 17.0: https://github.com/realm/SwiftLint/releases/tag/0.17.0